### PR TITLE
benchmarks for each type

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -6,7 +6,268 @@ import (
 	"testing"
 )
 
-//TODO >2X speedup on structs; do all the primitives too (EncodeInt vs Encode_int)
+func BenchmarkEncoder_EncodeInt(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeInt(int(1000)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkEncoder_Encode_int(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(int(1000)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeUInt8(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeUInt8(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_uint8(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(uint8(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeInt8(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeInt8(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_int8(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(int8(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeInt16(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeInt16(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_int16(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(int16(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeInt32(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeInt32(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_int32(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(int32(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeInt64(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeInt64(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_int64(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(int64(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeFloat32(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeFloat32(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_float32(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(float32(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeFloat64(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeFloat64(42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_float64(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(float64(42)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeChar(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeChar('a'); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_char(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(Char('a')); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeHighPrecNum(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeHighPrecNum("12345.6789"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_highPrecNum(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(HighPrecNumber("12345.6789")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeString(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeString("test"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_string(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode("test"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_EncodeBool(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.EncodeBool(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncoder_Encode_bool(b *testing.B) {
+	var buf []byte
+	e := NewEncoder(bytes.NewBuffer(buf))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := e.Encode(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
 
 func BenchmarkEncoder_Encode_struct(b *testing.B) {
 	var buf []byte


### PR DESCRIPTION
```
BenchmarkEncoder_EncodeInt-4            	20000000	        66.1 ns/op
BenchmarkEncoder_Encode_int-4           	20000000	        99.3 ns/op
BenchmarkEncoder_EncodeUInt8-4          	30000000	        55.6 ns/op
BenchmarkEncoder_Encode_uint8-4         	20000000	        91.1 ns/op
BenchmarkEncoder_EncodeInt8-4           	20000000	        55.5 ns/op
BenchmarkEncoder_Encode_int8-4          	20000000	        83.7 ns/op
BenchmarkEncoder_EncodeInt16-4          	30000000	        63.2 ns/op
BenchmarkEncoder_Encode_int16-4         	20000000	        91.1 ns/op
BenchmarkEncoder_EncodeInt32-4          	20000000	        63.4 ns/op
BenchmarkEncoder_Encode_int32-4         	20000000	        94.6 ns/op
BenchmarkEncoder_EncodeInt64-4          	20000000	        84.8 ns/op
BenchmarkEncoder_Encode_int64-4         	20000000	        98.7 ns/op
BenchmarkEncoder_EncodeFloat32-4        	20000000	        61.4 ns/op
BenchmarkEncoder_Encode_float32-4       	20000000	       105 ns/op
BenchmarkEncoder_EncodeFloat64-4        	20000000	        66.1 ns/op
BenchmarkEncoder_Encode_float64-4       	10000000	       101 ns/op
BenchmarkEncoder_EncodeChar-4           	20000000	        54.0 ns/op
BenchmarkEncoder_Encode_char-4          	20000000	        85.0 ns/op
BenchmarkEncoder_EncodeHighPrecNum-4    	20000000	        96.9 ns/op
BenchmarkEncoder_Encode_highPrecNum-4   	10000000	       148 ns/op
BenchmarkEncoder_EncodeString-4         	20000000	        93.5 ns/op
BenchmarkEncoder_Encode_string-4        	10000000	       150 ns/op
BenchmarkEncoder_EncodeBool-4           	30000000	        45.3 ns/op
BenchmarkEncoder_Encode_bool-4          	20000000	        76.7 ns/op
BenchmarkEncoder_Encode_struct-4        	  300000	      3816 ns/op
BenchmarkEncoder_EncodeValue_struct-4   	 1000000	      1776 ns/op
BenchmarkDecoder_Decode_struct-4        	  300000	      5184 ns/op
BenchmarkDecoder_DecodeValue_struct-4   	  500000	      2241 ns/op
```