### PR TITLE
basic 'ubjson' struct tag support

### DIFF
--- a/example_tag_test.go
+++ b/example_tag_test.go
@@ -1,0 +1,28 @@
+package ubjson_test
+
+import (
+	"fmt"
+
+	"github.com/jmank88/ubjson"
+)
+
+// A TaggedStruct has fields with 'ubjson' tags.
+type TaggedStruct struct {
+	Field1 string `ubjson:"field1"`
+	FieldA int    `json:"ignored" ubjson:"fieldA"`
+}
+
+func Example_taggedStruct() {
+	v := &TaggedStruct{Field1: "test", FieldA: 42}
+	if b, err := ubjson.MarshalBlock(v); err != nil {
+		fmt.Println("error: " + err.Error())
+	} else {
+		fmt.Println(string(b))
+	}
+
+	// Output:
+	// [{]
+	// 	[U][6][field1][S][U][4][test]
+	// 	[U][6][fieldA][U][42]
+	// [}]
+}

--- a/fields.go
+++ b/fields.go
@@ -1,0 +1,63 @@
+package ubjson
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
+
+// Based on 'encoding/json/encode.go'.
+var fieldCache struct {
+	value atomic.Value // map[reflect.Type]fields
+	mu    sync.Mutex   // used only by writers
+}
+
+// cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
+// Based on 'encoding/json/encode.go'.
+func cachedTypeFields(t reflect.Type) fields {
+	m, _ := fieldCache.value.Load().(map[reflect.Type]fields)
+	f, ok := m[t]
+	if ok {
+		return f
+	}
+
+	// Compute names without lock.
+	// Might duplicate effort but won't hold other computations back.
+	f = typeFields(t)
+
+	fieldCache.mu.Lock()
+	m, _ = fieldCache.value.Load().(map[reflect.Type]fields)
+	newM := make(map[reflect.Type]fields, len(m)+1)
+	for k, v := range m {
+		newM[k] = v
+	}
+	newM[t] = f
+	fieldCache.value.Store(newM)
+	fieldCache.mu.Unlock()
+	return f
+}
+
+// Indexes fields by 'ubjson' struct tag if present, otherwise name.
+func typeFields(t reflect.Type) fields {
+	fs := fields{
+		indexByName: make(map[string]int),
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath == "" {
+			name := f.Name
+			// Check for 'ubjson' struct tag.
+			if v, ok := f.Tag.Lookup("ubjson"); ok {
+				name = v
+			}
+			fs.names = append(fs.names, name)
+			fs.indexByName[name] = i
+		}
+	}
+	return fs
+}
+
+type fields struct {
+	names       []string
+	indexByName map[string]int
+}

--- a/ubjson.go
+++ b/ubjson.go
@@ -4,7 +4,7 @@
 // Most types can be automatically encoded through reflection with the Marshal
 // and Unmarshal functions. Encoders and Decoders additionally provide type
 // specific methods. Custom encodings can be defined by implementing the Value
-// interface.
+// interface. 'ubjson' struct tags can be used to override field names.
 //
 //	b, _ := ubjson.MarshalBlock(8)
 //	// [U][8]

--- a/ubjson_test.go
+++ b/ubjson_test.go
@@ -112,6 +112,18 @@ var cases = map[string]testCase{
 			'}'},
 		"[{]\n\t[U][1][A][i][5]\n\t[U][1][B][i][8]\n[}]",
 	},
+	"Object-Int8=struct-tagged": {
+		struct {
+			A int8 `ubjson:"a"`
+			a int  // Ignored - Exercises field index logic.
+			B int8 `json:"wrong" ubjson:"b"`
+		}{5, 0, 8},
+		[]byte{'{',
+			'U', 0x01, 'a', 'i', 0x05,
+			'U', 0x01, 'b', 'i', 0x08,
+			'}'},
+		"[{]\n\t[U][1][a][i][5]\n\t[U][1][b][i][8]\n[}]",
+	},
 
 	"Object=complex-struct": {complexStruct, complexStructBinary, complexStructBlock},
 	"Object=complex-map":    {complexMap, complexMapBinary, complexMapBlock},


### PR DESCRIPTION
Recognize 'ubjson' struct tags as alternatives to field names.  Towards #2.