### PR TITLE
reject strongly typed no-op

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -733,6 +733,9 @@ func objectAsInterface(o *ObjectDecoder) (interface{}, error) {
 	if o.Len > o.MaxCollectionAlloc {
 		return nil, errors.Errorf("collection exceeds max allocation limit of %d: %d", o.MaxCollectionAlloc, o.Len)
 	}
+	if o.ValType == NoOpMarker {
+		return nil, errors.New("No-Op (N) is not a legal strong type")
+	}
 	valType := elementTypeFor(o.ValType)
 	mapType := reflect.MapOf(stringType, valType)
 	mapValue := makeMap(mapType, o.Len)
@@ -755,6 +758,9 @@ func objectAsInterface(o *ObjectDecoder) (interface{}, error) {
 // be strongly typed, or an interface{} in the general case.
 func arrayAsInterface(a *ArrayDecoder) (interface{}, error) {
 	var sliceValue reflect.Value
+	if a.ElemType == NoOpMarker {
+		return nil, errors.New("No-Op (N) is not a legal strong type")
+	}
 	elemType := elementTypeFor(a.ElemType)
 	sliceType := reflect.SliceOf(elemType)
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -135,3 +135,17 @@ func TestDecoder_maxCollectionAlloc(t *testing.T) {
 		t.Error("expected error")
 	}
 }
+
+func TestFuzzUnmarshalBlock_strong_type_NoOp_array(t *testing.T) {
+	var i interface{}
+	if UnmarshalBlock([]byte("[[][$][N][#][I][512]"), &i) == nil {
+		t.Errorf("expected failure but got: %v", i)
+	}
+}
+
+func TestFuzzUnmarshalBlock_strong_type_NoOp_object(t *testing.T) {
+	var i interface{}
+	if UnmarshalBlock([]byte("[{][$][N][#][i][1][i][4][name]"), &i) == nil {
+		t.Errorf("expected failure but got: %v", i)
+	}
+}


### PR DESCRIPTION
Disallow decoding containers strongly typed as No-Op (previously fell back to `interface{}`).

Reacting to spec update: https://github.com/ubjson/universal-binary-json/pull/89