### PR TITLE
support empty string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-    - 1.9.x
-    - "1.10"
+    - 1.11.x
+    - 1.12.x
     - tip
 
 install:

--- a/reader.go
+++ b/reader.go
@@ -211,10 +211,12 @@ func (r *binaryReader) readString(max int) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read string length prefix")
 	}
-	if l < 1 {
+	switch {
+	case l == 0:
+		return "", nil
+	case l < 0:
 		return "", errors.Errorf("illegal string length prefix: %d", l)
-	}
-	if l > max {
+	case l > max:
 		return "", errors.Errorf("string length prefix exceeds max allocation limit of %d: %d", max, l)
 	}
 	b := make([]byte, l)
@@ -376,10 +378,12 @@ func (r *blockReader) readString(max int) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read string length prefix")
 	}
-	if l < 1 {
+	switch {
+	case l == 0:
+		return "", nil
+	case l < 0:
 		return "", errors.Errorf("illegal string length prefix: %d", l)
-	}
-	if l > max {
+	case l > max:
 		return "", errors.Errorf("string length prefix exceeds max allocation limit of %d: %d", max, l)
 	}
 	s, err := r.nextBlock()

--- a/ubjson_test.go
+++ b/ubjson_test.go
@@ -82,6 +82,7 @@ var cases = map[string]testCase{
 	"C=a": {Char('a'), []byte{'C', 0x61}, "[C][a]"},
 
 	"string=string": {"string", append([]byte{'S', 0x55, 0x06}, "string"...), "[S][U][6][string]"},
+	"string=empty": {"", []byte{'S', 0x55, 0x00}, "[S][U][0]"},
 
 	"Array-empty": {[0]int{}, []byte{0x5b, 0x23, 0x55, 0x0}, "[[][#][U][0]"},
 


### PR DESCRIPTION
This PR expands on #14 to add support for empty strings to `binaryReader` and `blockReader`, and updates the go versions used in CI.