### PR TITLE
Allow `readBuff` and `readString` to succeed even when multiple `Read` calls are needed

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -152,12 +152,9 @@ func (r *binaryReader) readInt8() (int8, error) {
 // The readBuf method reads len bytes into r.buf. len must not exceed 8.
 func (r *binaryReader) readBuf(len int) ([]byte, error) {
 	b := r.buf[:len]
-	n, err := r.Read(b)
+	_, err := io.ReadFull(r, b)
 	if err != nil {
 		return nil, err
-	}
-	if n != len {
-		return nil, errors.New("TODO failed to read enough bytes")
 	}
 	return b, nil
 }

--- a/reader.go
+++ b/reader.go
@@ -216,12 +216,9 @@ func (r *binaryReader) readString(max int) (string, error) {
 		return "", fmt.Errorf("string length prefix exceeds max allocation limit of %d: %d", max, l)
 	}
 	b := make([]byte, l)
-	n, err := r.Read(b)
+	_, err = io.ReadFull(r, b)
 	if err != nil {
 		return "", fmt.Errorf("failed to read string bytes: %w", err)
-	}
-	if n != l {
-		return "", fmt.Errorf("failed to read full string length (%d), instead got: %s", l, string(b[:n]))
 	}
 	return string(b), nil
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -18,3 +18,16 @@ func TestReadBuf(t *testing.T) {
 		t.Errorf("\nexpected: %#v\nbut got:  %#v", expected, bytes)
 	}
 }
+
+func TestReadString(t *testing.T) {
+	expected := "abcdefgh"
+	readerData := append([]byte{'U', 8}, expected...)
+	r := newBinaryReader(iotest.OneByteReader(bytes.NewReader(readerData)))
+	str, err := r.readString(8)
+	if err != nil {
+		t.Fatalf("failed to readBuf: %+v\n", err)
+	}
+	if str != expected {
+		t.Errorf("\nexpected: %#v\nbut got:  %#v", expected, str)
+	}
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,20 @@
+package ubjson
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"testing/iotest"
+)
+
+func TestReadBuf(t *testing.T) {
+	expected := []byte("abcdefgh")
+	r := newBinaryReader(iotest.OneByteReader(bytes.NewReader(expected)))
+	bytes, err := r.readBuf(8)
+	if err != nil {
+		t.Fatalf("failed to readBuf: %+v\n", err)
+	}
+	if !reflect.DeepEqual(bytes, expected) {
+		t.Errorf("\nexpected: %#v\nbut got:  %#v", expected, bytes)
+	}
+}


### PR DESCRIPTION
The `readBuff` and `readString` methods in `binaryReader` were directly calling `Read` on their buffered reader. The `Read` method may not fill the entire buffer that it is passed, so calls to `readBuff` and `readString` could fail when the buffered reader's buffer only contained part of the data to be read.

`io.ReaderFull` does what we want: it calls `Read` on the reader multiple times if needed in order to fill our buffer, returning an error only if there really isn't enough data left in the reader.